### PR TITLE
Add dependency for splitted of network-uri package

### DIFF
--- a/shuffle.cabal
+++ b/shuffle.cabal
@@ -22,6 +22,10 @@ Source-Repository head
   Type:              git
   Location:          https://github.com/UU-ComputerScience/shuffle.git
 
+flag network-uri
+   description: Get Network.URI from the network-uri package
+   default: True
+
 Library
   Hs-Source-Dirs:    src
   Extensions:        RankNTypes, TypeSynonymInstances, FlexibleInstances, FlexibleContexts
@@ -40,7 +44,6 @@ Library
   Build-Depends:     base >= 4 && < 5,
                      containers >= 0.4,
                      directory >= 1.1,
-                     network >= 2.3,
                      process >= 1.1,
                      array >= 0.4,
                      uulib >= 0.9,
@@ -49,6 +52,11 @@ Library
                      uhc-util >= 0.1.0.2,
                      Cabal >= 1.14,
                      filepath >= 1.2
+  if flag(network-uri)
+    build-depends:   network-uri >= 2.6,
+                     network >= 2.6
+  else
+    build-depends:   network >= 2.3 && < 2.6
 
 Executable shuffle
   Hs-Source-Dirs:    src-main


### PR DESCRIPTION
The Network.URI module has been split off into the seperate network-uri package, which breaks the shuffle build. (see http://hackage.haskell.org/package/network-2.6.0.1 )
