### PR TITLE
GHC 7.10 support

### DIFF
--- a/src/UHC/Shuffle/ChunkParser.hs
+++ b/src/UHC/Shuffle/ChunkParser.hs
@@ -236,9 +236,9 @@ pWhiteBlack = (\t -> (mbTokWhite t,tokBlack t)) <$> pText
 -- Shuffle chunk parser
 -------------------------------------------------------------------------
 
-type ShPr  c = (IsParser p Tok) => p c
-type ShPr2 c = (IsParser p Tok) => p c -> p c
-type ShPr3 c = (IsParser p Tok) => p c -> p c -> p c
+type ShPr  c = forall p . (IsParser p Tok) => p c
+type ShPr2 c = forall p . (IsParser p Tok) => p c -> p c
+type ShPr3 c = forall p . (IsParser p Tok) => p c -> p c -> p c
 
 mkNmForP :: String -> [String] -> Nm
 mkNmForP h t = nmFromL . concat . map (wordsBy (=='.')) $ (h : t)

--- a/src/UHC/Shuffle/Common.hs
+++ b/src/UHC/Shuffle/Common.hs
@@ -127,72 +127,72 @@ type KVMap = Map.Map String String
 
 data Opts 
   = Opts
-      { optAG           		:: Bool						-- generate AG
-      , optHS           		:: Bool						-- generate Haskell
-      , optPlain        		:: Bool						-- leave as is
-      , optLaTeX        		:: Bool						-- generate latex
-      , optPreamble     		:: Bool						-- include preamble
-      , optLinePragmas  		:: Bool						-- include line pragmas
-      , optIndex        		:: Bool
-      , optCompiler     		:: [Int]
-      , optHelp         		:: Bool
-      , optVersion         		:: Bool
-      , optGenDeps      		:: Bool
-      , optGenText2Text   		:: Bool						-- include text2text text type annotation
-      , optChDest       		:: (ChDest,String)
-      , optGenReqm   			:: VariantReqm
-      , optBaseName     		:: Maybe String
-      , optBaseFPath    		:: FPath
-      , optWrapLhs2tex  		:: ChWrap
-      , optMbXRefExcept 		:: Maybe String
-      , optVariantRefOrder		:: VariantRefOrder
-      , optDefs         		:: KVMap
-      , optDepNamePrefix 		:: String
-      , optDepSrcVar     		:: String
-      , optDepDstVar     		:: String
-      , optDepMainVar    		:: String
-      , optDepDpdsVar    		:: String
-      , optDepOrigDpdsVar 		:: String
-      , optDepDerivDpdsVar 		:: String
-      , optDepBaseDir     		:: String
-      , optDepTerm        		:: Map String [String]
-      , optDepIgn         		:: Set String
-      , optAGModHeader    		:: Bool
+      { optAG                   :: Bool                     -- generate AG
+      , optHS                   :: Bool                     -- generate Haskell
+      , optPlain                :: Bool                     -- leave as is
+      , optLaTeX                :: Bool                     -- generate latex
+      , optPreamble             :: Bool                     -- include preamble
+      , optLinePragmas          :: Bool                     -- include line pragmas
+      , optIndex                :: Bool
+      , optCompiler             :: [Int]
+      , optHelp                 :: Bool
+      , optVersion              :: Bool
+      , optGenDeps              :: Bool
+      , optGenText2Text         :: Bool                     -- include text2text text type annotation
+      , optChDest               :: (ChDest,String)
+      , optGenReqm              :: VariantReqm
+      , optBaseName             :: Maybe String
+      , optBaseFPath            :: FPath
+      , optWrapLhs2tex          :: ChWrap
+      , optMbXRefExcept         :: Maybe String
+      , optVariantRefOrder      :: VariantRefOrder
+      , optDefs                 :: KVMap
+      , optDepNamePrefix        :: String
+      , optDepSrcVar            :: String
+      , optDepDstVar            :: String
+      , optDepMainVar           :: String
+      , optDepDpdsVar           :: String
+      , optDepOrigDpdsVar       :: String
+      , optDepDerivDpdsVar      :: String
+      , optDepBaseDir           :: String
+      , optDepTerm              :: Map String [String]
+      , optDepIgn               :: Set String
+      , optAGModHeader          :: Bool
       } deriving (Show)
 
 defaultOpts
   = Opts
-      { optAG           		=  False
-      , optHS           		=  False
-      , optLaTeX        		=  False
-      , optPreamble     		=  True
-      , optLinePragmas  		=  False
-      , optPlain        		=  False
-      , optIndex        		=  False
-      , optCompiler     		=  []
-      , optHelp         		=  False
-      , optVersion         		=  False
-      , optGenDeps      		=  False
-      , optGenText2Text			=  False
-      , optChDest       		=  (ChHere,"")
-      , optGenReqm   			=  VReqmNone
-      , optBaseName     		=  Nothing
-      , optBaseFPath    		=  emptyFPath
-      , optWrapLhs2tex  		=  ChWrapCode
-      , optMbXRefExcept 		=  Nothing
-      , optVariantRefOrder	 	=  [[]]
-      , optDefs					=  Map.empty
-      , optDepNamePrefix 		=  error "optDepNamePrefix not set"
-      , optDepSrcVar     		=  error "optDepSrcVar not set"
-      , optDepDstVar     		=  error "optDepDstVar not set"
-      , optDepMainVar    		=  error "optDepMainVar not set"
-      , optDepDpdsVar    		=  error "optDepDpdsVar not set"
-      , optDepOrigDpdsVar 		=  error "optDepOrigDpdsVar not set"
-      , optDepDerivDpdsVar 		=  error "optDepDerivDpdsVar not set"
-      , optDepBaseDir     		=  error "optDepBaseDir not set"
-      , optDepTerm        		=  Map.empty
-      , optDepIgn         		=  Set.empty
-      , optAGModHeader    		=  True
+      { optAG                   =  False
+      , optHS                   =  False
+      , optLaTeX                =  False
+      , optPreamble             =  True
+      , optLinePragmas          =  False
+      , optPlain                =  False
+      , optIndex                =  False
+      , optCompiler             =  []
+      , optHelp                 =  False
+      , optVersion              =  False
+      , optGenDeps              =  False
+      , optGenText2Text         =  False
+      , optChDest               =  (ChHere,"")
+      , optGenReqm              =  VReqmNone
+      , optBaseName             =  Nothing
+      , optBaseFPath            =  emptyFPath
+      , optWrapLhs2tex          =  ChWrapCode
+      , optMbXRefExcept         =  Nothing
+      , optVariantRefOrder      =  [[]]
+      , optDefs                 =  Map.empty
+      , optDepNamePrefix        =  error "optDepNamePrefix not set"
+      , optDepSrcVar            =  error "optDepSrcVar not set"
+      , optDepDstVar            =  error "optDepDstVar not set"
+      , optDepMainVar           =  error "optDepMainVar not set"
+      , optDepDpdsVar           =  error "optDepDpdsVar not set"
+      , optDepOrigDpdsVar       =  error "optDepOrigDpdsVar not set"
+      , optDepDerivDpdsVar      =  error "optDepDerivDpdsVar not set"
+      , optDepBaseDir           =  error "optDepBaseDir not set"
+      , optDepTerm              =  Map.empty
+      , optDepIgn               =  Set.empty
+      , optAGModHeader          =  True
       }
 
 optsHasNoVariantRefOrder :: Opts -> Bool
@@ -223,8 +223,8 @@ data ChKind
   = ChAG
   | ChHS
   | ChPlain
-  | ChDocLaTeX		-- restricted LaTeX for documentation
-  | ChLhs2TeX		-- lhs2tex
+  | ChDocLaTeX      -- restricted LaTeX for documentation
+  | ChLhs2TeX       -- lhs2tex
   -- | ChTexInfo
   -- | ChHtml
   -- | ChTwiki
@@ -238,15 +238,15 @@ data ChDest
 data ChWrap
   = ChWrapCode
   | ChWrapHsBox
-  | ChWrapBoxCode 			(Maybe String)
-  | ChWrapBeamerBlockCode 	String
+  | ChWrapBoxCode           (Maybe String)
+  | ChWrapBeamerBlockCode   String
   | ChWrapTT
   | ChWrapTTtiny
   | ChWrapVerbatim
   | ChWrapVerbatimSmall
   | ChWrapPlain
-  | ChWrapT2T				ChKind				-- wrap for text2text
-  | ChWrapComp				ChWrap ChWrap		-- compose
+  | ChWrapT2T               ChKind              -- wrap for text2text
+  | ChWrapComp              ChWrap ChWrap       -- compose
   | ChWrapNone
   deriving (Show,Eq,Ord)
 
@@ -265,7 +265,7 @@ t2tChKinds
 -------------------------------------------------------------------------
 
 data VariantRef
-  = VarRef 	{vrefRefs :: ![Int]}
+  = VarRef  {vrefRefs :: ![Int]}
   deriving (Show,Eq,Ord)
 
 variantRefIsPre :: VariantRef -> Bool
@@ -309,8 +309,8 @@ data VariantOfferForCompare
 
 data VariantOffer
   = VOfferAll
-  | VOfferPre	{                              vofferAspect :: !AspectRefs}
-  | VOfferRef 	{vofferVariant :: !VariantRef, vofferAspect :: !AspectRefs}
+  | VOfferPre   {                              vofferAspect :: !AspectRefs}
+  | VOfferRef   {vofferVariant :: !VariantRef, vofferAspect :: !AspectRefs}
   deriving (Show,Eq,Ord)
 
 variantOfferIsPre :: VariantOffer -> Bool
@@ -327,9 +327,9 @@ instance Ord VariantOffer where
   _                 `compare` VOfferAll          = GT
   _                 `compare` VOfferPre          = GT
   (VOfferRef r1 a1) `compare` (VOfferRef r2 a2)  = case r1 `compare` r2 of
-                    								 EQ -> case (a1,a2) of
-                    								         (AspectAll,AspectAll) -> EQ
-                    								         (_        ,AspectAll) ->
+                                                     EQ -> case (a1,a2) of
+                                                             (AspectAll,AspectAll) -> EQ
+                                                             (_        ,AspectAll) ->
 -}
 
 type VariantRefOrder   = [[VariantRef]]
@@ -393,7 +393,7 @@ instance NM VariantOffer where
 data VariantReqm
   = VReqmAll
   | VReqmNone
-  | VReqmRef 	{ vreqmVariant :: !VariantRef, vreqmAspects :: !AspectRefs }
+  | VReqmRef    { vreqmVariant :: !VariantRef, vreqmAspects :: !AspectRefs }
   deriving (Show,Eq,Ord)
 
 variantReqmIsPre :: VariantReqm -> Bool

--- a/src/UHC/Shuffle/MainAG.ag
+++ b/src/UHC/Shuffle/MainAG.ag
@@ -395,7 +395,7 @@ ATTR AllWord [ | | cdoc USE {.|.} {CDoc_Emp} : CDoc ]
 
 SEM Word
   | White Black lhs         .   cdoc        =   cd @chars
-  | Expand      lhs         .   cdoc		=	cd @exp.str
+  | Expand      lhs         .   cdoc        =   cd @exp.str
 
 SEM Inline
   | URI         lhs         .   cdoc        =   CDoc_Inl @str
@@ -443,19 +443,19 @@ SEM Group
 {
 data VariantChunkInfo
   = VariantChunkInfo
-      { vciLineNr   		:: Int
-      , vciSeqNr    		:: Int
+      { vciLineNr           :: Int
+      , vciSeqNr            :: Int
       , vciVariantOffer     :: VariantOffer
       , vciChunkRef         :: ChunkRef
-      , vciMinusL   		:: [ChunkRef]
-      , vciChKind   		:: ChKind
-      , vciChDest   		:: ChDest
-      , vciMbModNm  		:: Maybe String
-      , vciImps     		:: [String]
-      , vciExps     		:: [String]
-      , vciMbCD     		:: Maybe CDoc
-      , vciMkCD     		:: MkCDoc
-      , vciXRefL    		:: [XRef]
+      , vciMinusL           :: [ChunkRef]
+      , vciChKind           :: ChKind
+      , vciChDest           :: ChDest
+      , vciMbModNm          :: Maybe String
+      , vciImps             :: [String]
+      , vciExps             :: [String]
+      , vciMbCD             :: Maybe CDoc
+      , vciMkCD             :: MkCDoc
+      , vciXRefL            :: [XRef]
       } deriving Show
 
 type VariantChunkInfoM = [(VariantOffer,[VariantChunkInfo])]
@@ -543,11 +543,11 @@ selectChunks appMinus variantReqm allowedVariants agl
 
 data Build
   = Build
-      { bldBase     		:: String
+      { bldBase             :: String
       , bldVariantReqm      :: VariantReqm
-      , bldCD       		:: CDoc
-      , bldHideCD   		:: [(Nm,CDoc)]
-      , bldNmChMp   		:: NmChMp
+      , bldCD               :: CDoc
+      , bldHideCD           :: [(Nm,CDoc)]
+      , bldNmChMp           :: NmChMp
       }
 }
 

--- a/src/UHC/Shuffle/MainAG.ag
+++ b/src/UHC/Shuffle/MainAG.ag
@@ -1,3 +1,6 @@
+optpragmas {
+{-# LANGUAGE CPP #-}
+}
 MODULE {UHC.Shuffle.MainAG} {}
 {
 import Network.URI
@@ -14,6 +17,10 @@ import UHC.Shuffle.CDocInline
 import qualified Data.Set as Set
 import qualified UHC.Util.FastSeq as Seq
 import UHC.Util.Utils(initlast)
+
+#if __GLASGOW_HASKELL__ >= 710
+import Prelude hiding (Word)
+#endif
 
 -- for debugging:
 -- import UHC.Util.Utils (tr, trp, wordsBy)


### PR DESCRIPTION
PR tested with GHC 7.8 and 7.10. Contains the following things:
- Small fix for GHC 7.10 support
- Eliminates warnings in GHC 7.10 (tabs, explicit foralls)