### PR TITLE
Support Cabal 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 dist
 dist-*
-src/UHC/Shuffle/Version.hs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+dist-*
+src/UHC/Shuffle/Version.hs

--- a/Setup.hs
+++ b/Setup.hs
@@ -2,30 +2,5 @@ import Distribution.Simple (defaultMainWithHooks)
 import Distribution.Simple.UUAGC (uuagcLibUserHook)
 import UU.UUAGC (uuagc)
 
-{-
 main :: IO ()
-main = defaultMainWithHooks $
-         uuagcLibUserHook uuagc
--}
-
-{-
--}
-import Distribution.PackageDescription
-import Distribution.Simple.UserHooks
-import Distribution.Package
-import Distribution.Version
-import qualified Data.Version
-
-main :: IO ()
-main = defaultMainWithHooks $
-         addHook $
-         uuagcLibUserHook uuagc
-  where addHook hooks = hooks {
-            postConf = postConf_InsertVersion hooks
-          }
-        -- postConf_InsertVersion :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO ()
-        postConf_InsertVersion hooks args cfg pkgDescr bi = do
-          postConf hooks args cfg pkgDescr bi
-          writeFile "src/UHC/Shuffle/Version.hs" $
-            "module UHC.Shuffle.Version where\n" ++
-            "version = \"" ++ Data.Version.showVersion (Data.Version.makeVersion $ versionNumbers $ pkgVersion $ package pkgDescr) ++ "\"\n"
+main = defaultMainWithHooks $ uuagcLibUserHook uuagc

--- a/Setup.hs
+++ b/Setup.hs
@@ -14,7 +14,7 @@ import Distribution.PackageDescription
 import Distribution.Simple.UserHooks
 import Distribution.Package
 import Distribution.Version
--- import Data.Version
+import qualified Data.Version
 
 main :: IO ()
 main = defaultMainWithHooks $
@@ -28,4 +28,4 @@ main = defaultMainWithHooks $
           postConf hooks args cfg pkgDescr bi
           writeFile "src/UHC/Shuffle/Version.hs" $
             "module UHC.Shuffle.Version where\n" ++
-            "version = \"" ++ showVersion (pkgVersion $ package pkgDescr) ++ "\"\n"
+            "version = \"" ++ Data.Version.showVersion (Data.Version.makeVersion $ versionNumbers $ pkgVersion $ package pkgDescr) ++ "\"\n"

--- a/shuffle.cabal
+++ b/shuffle.cabal
@@ -38,8 +38,8 @@ Library
   default-language:  Haskell2010
   default-extensions:RankNTypes, TypeSynonymInstances, FlexibleInstances, FlexibleContexts
   Exposed-Modules:   UHC.Shuffle,
-                     UHC.Shuffle.Version,
-                     Distribution.Simple.Shuffle
+                     Distribution.Simple.Shuffle,
+                     UHC.Shuffle.Version
   Other-Modules:     UHC.Shuffle.AspectExpr,
                      UHC.Shuffle.AspectExprEval,
                      UHC.Shuffle.CDoc,
@@ -48,13 +48,15 @@ Library
                      UHC.Shuffle.CDocSubst,
                      UHC.Shuffle.ChunkParser,
                      UHC.Shuffle.Common,
-                     UHC.Shuffle.MainAG
+                     UHC.Shuffle.MainAG,
+                     Paths_shuffle
   autogen-modules:   UHC.Shuffle.AspectExpr,
                      UHC.Shuffle.AspectExprEval,
                      UHC.Shuffle.CDoc,
                      UHC.Shuffle.CDocInline,
                      UHC.Shuffle.CDocSubst,
-                     UHC.Shuffle.MainAG
+                     UHC.Shuffle.MainAG,
+                     Paths_shuffle
   Build-Depends:     base >= 4 && < 5,
                      containers >= 0.4,
                      directory >= 1.1,

--- a/shuffle.cabal
+++ b/shuffle.cabal
@@ -1,3 +1,4 @@
+Cabal-Version:       2.4
 Name:                shuffle
 Version:             0.1.4.0
 Copyright:           Utrecht University, Department of Information and Computing Sciences, Software Technology group
@@ -5,25 +6,15 @@ Description:         Shuffle tool used by UHC (Utrecht Haskell Compiler)
 Synopsis:            Shuffle tool for UHC
 Homepage:            https://github.com/UU-ComputerScience/shuffle
 Bug-Reports:         https://github.com/UU-ComputerScience/shuffle/issues
-License:             BSD3
+License:             BSD-3-Clause
 License-file:        LICENSE
 Author:              UHC Team
 Maintainer:          uhc-developers@lists.science.uu.nl
 Category:            Development
 Build-Type:          Custom
-Cabal-Version:       2.0
 Extra-Source-Files:  uuagc_options,
                      changelog.md,
-                     src/UHC/Shuffle/AspectExpr.ag,
-                     src/UHC/Shuffle/AspectExprAbsSyn.ag,
-                     src/UHC/Shuffle/AspectExprEval.ag,
-                     src/UHC/Shuffle/CDoc.ag,
-                     src/UHC/Shuffle/CDocAbsSyn.ag,
-                     src/UHC/Shuffle/CDocCommonAG.ag,
-                     src/UHC/Shuffle/CDocInline.ag,
-                     src/UHC/Shuffle/CDocSubst.ag,
-                     src/UHC/Shuffle/ChunkAbsSyn.ag,
-                     src/UHC/Shuffle/MainAG.ag
+                     src/**/*.ag
 
 Source-Repository head
   Type:              git

--- a/shuffle.cabal
+++ b/shuffle.cabal
@@ -11,13 +11,19 @@ Author:              UHC Team
 Maintainer:          uhc-developers@lists.science.uu.nl
 Category:            Development
 Build-Type:          Custom
-Cabal-Version:       >= 1.23
+Cabal-Version:       2.0
 Extra-Source-Files:  uuagc_options,
                      changelog.md,
+                     src/UHC/Shuffle/AspectExpr.ag,
                      src/UHC/Shuffle/AspectExprAbsSyn.ag,
+                     src/UHC/Shuffle/AspectExprEval.ag,
+                     src/UHC/Shuffle/CDoc.ag,
                      src/UHC/Shuffle/CDocAbsSyn.ag,
                      src/UHC/Shuffle/CDocCommonAG.ag,
-                     src/UHC/Shuffle/ChunkAbsSyn.ag
+                     src/UHC/Shuffle/CDocInline.ag,
+                     src/UHC/Shuffle/CDocSubst.ag,
+                     src/UHC/Shuffle/ChunkAbsSyn.ag,
+                     src/UHC/Shuffle/MainAG.ag
 
 Source-Repository head
   Type:              git
@@ -36,12 +42,18 @@ Library
                      Distribution.Simple.Shuffle
   Other-Modules:     UHC.Shuffle.AspectExpr,
                      UHC.Shuffle.AspectExprEval,
-                     UHC.Shuffle.Common,
                      UHC.Shuffle.CDoc,
                      UHC.Shuffle.CDocCommon,
-                     UHC.Shuffle.CDocSubst,
                      UHC.Shuffle.CDocInline,
+                     UHC.Shuffle.CDocSubst,
                      UHC.Shuffle.ChunkParser,
+                     UHC.Shuffle.Common,
+                     UHC.Shuffle.MainAG
+  autogen-modules:   UHC.Shuffle.AspectExpr,
+                     UHC.Shuffle.AspectExprEval,
+                     UHC.Shuffle.CDoc,
+                     UHC.Shuffle.CDocInline,
+                     UHC.Shuffle.CDocSubst,
                      UHC.Shuffle.MainAG
   Build-Depends:     base >= 4 && < 5,
                      containers >= 0.4,
@@ -50,9 +62,10 @@ Library
                      array >= 0.4,
                      uulib >= 0.9,
                      uuagc >= 0.9.40.3,
-                     uuagc-cabal >= 1.1.0.0,
+                     uuagc-cabal >= 1.2.0.0,
                      uhc-util >= 0.1.5.5,
-                     Cabal >= 2.0.0.2,
+                     Cabal >= 3.0.0.0,
+                     parsec >= 3.1.13.0,
                      filepath >= 1.2
   if flag(network-uri)
     build-depends:   network-uri >= 2.6,
@@ -69,6 +82,6 @@ Executable shuffle
 
 custom-setup
   setup-depends:     base >= 4 && < 5,
-                     uuagc-cabal >= 1.1.0.0,
+                     uuagc-cabal >= 1.2.0.0,
                      uuagc >= 0.9.40.3,
-                     Cabal >= 2.0.0.2
+                     Cabal >= 3.0.0.0

--- a/src/UHC/Shuffle/Version.hs
+++ b/src/UHC/Shuffle/Version.hs
@@ -1,0 +1,7 @@
+module UHC.Shuffle.Version (version) where
+
+import qualified Paths_shuffle (version)
+import Data.Version (showVersion)
+
+version :: String
+version = showVersion Paths_shuffle.version


### PR DESCRIPTION
For now, I have commented out the sdist hook. I think most of its functionality should be replaced by having users manually list modules in the new `autogen-modules` field. Maybe this can be automated in some way?

I have also added some files to the `extra-source-files` field. Now `cabal v2-install` works as expected.